### PR TITLE
feat: add Help link in app header (lightweight)

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -1,8 +1,13 @@
+import { Header } from '@/components/Header';
+
 export default function Dashboard() {
   return (
-    <main className="min-h-dvh p-8 bg-[hsl(var(--bg))]">
-      <h1 className="text-2xl font-semibold text-[hsl(var(--text))] mb-2">Dashboard</h1>
-      <p className="text-[hsl(var(--text-muted))]">Signed-in area (public for now; auth later).</p>
-    </main>
+    <div className="min-h-dvh bg-[hsl(var(--bg))]">
+      <Header />
+      <main className="p-8">
+        <h1 className="text-2xl font-semibold text-[hsl(var(--text))] mb-2">Dashboard</h1>
+        <p className="text-[hsl(var(--text-muted))]">Signed-in area (public for now; auth later).</p>
+      </main>
+    </div>
   );
 }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,0 +1,26 @@
+export function Header() {
+  return (
+    <header className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface))]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <div className="flex items-center">
+            <span className="text-xl font-semibold text-[hsl(var(--text))]">
+              Your Starter
+            </span>
+          </div>
+          <nav className="flex items-center space-x-4">
+            <a
+              href="https://github.com/Shredvardson/dl-starter/wiki/Home"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[hsl(var(--text-muted))] hover:text-[hsl(var(--text))] transition-colors"
+              data-testid="help-link"
+            >
+              Help
+            </a>
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/web/tests/help-link.spec.ts
+++ b/apps/web/tests/help-link.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Help Link', () => {
+  test('should render Help link in header and return 200 status', async ({ page }) => {
+    // Navigate to dashboard page
+    await page.goto('/dashboard');
+
+    // Assert Help link is visible
+    const helpLink = page.getByTestId('help-link');
+    await expect(helpLink).toBeVisible();
+    await expect(helpLink).toHaveText('Help');
+
+    // Check the href attribute points to wiki Home
+    await expect(helpLink).toHaveAttribute('href', 'https://github.com/Shredvardson/dl-starter/wiki/Home');
+
+    // Check that target and rel attributes are set correctly for security
+    await expect(helpLink).toHaveAttribute('target', '_blank');
+    await expect(helpLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    // Test that the link responds with 200 (using HEAD request to avoid following redirect)
+    const linkUrl = await helpLink.getAttribute('href');
+    if (linkUrl) {
+      const response = await page.request.head(linkUrl);
+      expect(response.status()).toBe(200);
+    }
+  });
+
+  test('should open wiki in new tab when clicked', async ({ page, context }) => {
+    await page.goto('/dashboard');
+
+    const helpLink = page.getByTestId('help-link');
+    await expect(helpLink).toBeVisible();
+
+    // Listen for new page events
+    const pagePromise = context.waitForEvent('page');
+    await helpLink.click();
+    
+    // Verify new page opens with correct URL (GitHub may redirect, so check for wiki path)
+    const newPage = await pagePromise;
+    await newPage.waitForLoadState();
+    expect(newPage.url()).toContain('github.com/Shredvardson/dl-starter');
+  });
+});

--- a/apps/web/tests/help-link.spec.ts
+++ b/apps/web/tests/help-link.spec.ts
@@ -15,7 +15,8 @@ test.describe('Help Link', () => {
 
     // Check that target and rel attributes are set correctly for security
     await expect(helpLink).toHaveAttribute('target', '_blank');
-    await expect(helpLink).toHaveAttribute('rel', 'noopener noreferrer');
+    const rel = (await helpLink.getAttribute('rel')) || '';
+    expect(rel.split(/\s+/)).toEqual(expect.arrayContaining(['noopener', 'noreferrer']));
 
     // Test that the link responds with 200 (using HEAD request to avoid following redirect)
     const linkUrl = await helpLink.getAttribute('href');


### PR DESCRIPTION
# Add Help Link in App Header

## Summary
Adds Help link in app header pointing to GitHub Wiki Home page with comprehensive e2e testing.

## Scope
- [x] Single component change (Header + Dashboard integration)
- [x] Files touched: Header.tsx, dashboard/page.tsx, help-link.spec.ts

## Lightweight Definition of Done ✅
- [x] **No files in specs/|plans/|tasks/** ✅ (lightweight lane)
- [x] **Tests added/updated** ✅ (comprehensive e2e test suite)  
- [x] **Lint/tests green** ✅ (all checks passing)
- [x] **PR links back to Issue** → Following burn-in plan from GPT-5

## Implementation Details
- **Header Component**: Clean, secure external link with proper rel attributes
- **Dashboard Integration**: Header added to signed-in area layout
- **E2E Testing**: Link visibility, URL validation, new tab behavior, 200 response
- **Security**: Uses `rel="noopener noreferrer"` and `target="_blank"`

## Verification ✅
- [x] `pnpm run lint` → All packages passing
- [x] `pnpm run typecheck` → No type errors  
- [x] `pnpm run test:e2e:ci` → Help link tests passing
- [x] Manual verification → Link opens Wiki Home in new tab

## AI Review Status  
- [x] **Security Review**: Manual review completed (secure external link practices)

**🔥 LIGHTWEIGHT LANE VALIDATED** - Single component, <2 hours, no ceremony, tests green!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent dashboard header with brand text and a Help link that opens the project wiki in a new tab.
* **Refactor**
  * Updated dashboard layout: removed outer padding and introduced an inner padded main area for content.
* **Tests**
  * Added end-to-end tests verifying the Help link’s visibility, label, URL, security attributes, that it opens in a new tab, and a link health check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->